### PR TITLE
Adjust include regex so this applies to both existing and new issue screens

### DIFF
--- a/uncheck-email-all.user.js
+++ b/uncheck-email-all.user.js
@@ -4,7 +4,7 @@
 // @version      0.1
 // @description  Uncheck the email all checkbox
 // @author       You
-// @include      /^https:\/\/central.tri.be\/issues\/.*/
+// @include      /^https:\/\/central.tri.be(\/.*)?/
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
The existing @include regex excludes the add new issue URL (`https://central.tri.be/projects/bushel/issues/new`). I'd like to loosen the regex to work anywhere within Central.