### PR TITLE
Add script to hide the releases on GitHub's homepage

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -7,3 +7,7 @@ Auto selects some checkboxes for setting default branch protection on Products i
 ## `github-pull-prefix-removal.user.js`
 
 When viewing Pull Requests on GitHub, if the PR is against a Modern Tribe repo, it removes the `moderntribe/` prefix for easier scanning.
+
+## `github-home-block-releases.js`
+
+Hides the releases `div`s on GitHub's homepage to declutter it

--- a/github/github-home-block-releases.js
+++ b/github/github-home-block-releases.js
@@ -1,0 +1,41 @@
+// ==UserScript==
+// @name         GitHub Block Releases
+// @namespace    https://github.com/saya-rbt
+// @version      1.0
+// @description  Hides the releases on GitHub's homepage
+// @author       Saya @saya-rbt
+// @match        https://github.com/
+// @icon         https://www.google.com/s2/favicons?domain=github.com
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+    console.log("Running GitHub Block Releases...");
+
+    // Select the node that will be observed for mutations
+    const targetNode = document.getElementsByClassName('news')[0];
+
+    // Options for the observer (which mutations to observe)
+    const config = {childList: true, subtree: true, characterData: true};
+
+    // Callback function to execute when mutations are observed
+    const callback = function(mutationsList, observer) {
+        // Use traditional 'for loops' for IE 11
+        for(const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                var divs = document.getElementsByClassName("release");
+                for(var i = 0; i < divs.length; i++) {
+                    divs[i].style.visibility = 'hidden';
+                    divs[i].style.height = '0';
+                }
+            }
+        }
+    };
+
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(callback);
+
+    // Start observing the target node for configured mutations
+    observer.observe(targetNode, config);
+})();


### PR DESCRIPTION
Hello,

I made this small script to hide the releases on GitHub's homepage. I made my own repo for it [here](https://github.com/saya-rbt/github-home-block-releases), but then found this repo, so I thought might as well contribute it here 😊 

If there's anything bothering you please let me know!

EDIT: I just realized this was a repo for your specific usage, not general Tampermonkey scripts. I keep the PR open in case it might still be useful to you guys, but if not it's fine if you refuse it 😊 